### PR TITLE
v2.1.0: add fluent API and simplified lifecycle management

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ognick/goscade/example/pkg"
 )
 
+const addr = "127.0.0.1:8080"
+
 func main() {
 	log := pkg.NewLogger(pkg.LoggerCfg{
 		Level:         "info",
@@ -18,26 +20,23 @@ func main() {
 		DisableJson:   true,
 	})
 
-	lc := goscade.NewLifecycle(log)
+	// Create lifecycle with signal handling enabled
+	lc := goscade.NewLifecycle(log, goscade.WithShutdownHook())
 	lc.Register(pkg.NewServer(
+		addr,
 		api.NewHandler(
 			log,
 			usecase.NewUsecase(log),
 		),
 	))
 
-	waitGracefulShutdown := lc.Run(context.Background(), func(err error) {
-		if err != nil {
-			log.Errorf("readiness probe failed: %v", err)
-		} else {
-			log.Info("Server started on http://127.0.0.1:8080")
-		}
+	// Run lifecycle with blocking behavior and readiness callback
+	// The lifecycle will block until shutdown and call the callback when ready
+	err := goscade.Run(context.Background(), lc, func() {
+		log.Infof("HTTP started on http://%s", addr)
 	})
-
-	// Awaiting graceful shutdown
-	if err := waitGracefulShutdown(); err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatalf("%v", err)
 	}
-
 	log.Info("Application gracefully finished")
 }

--- a/example/pkg/server.go
+++ b/example/pkg/server.go
@@ -13,9 +13,9 @@ type HttpServer struct {
 	*http.Server
 }
 
-func NewServer(handler http.Handler) *HttpServer {
+func NewServer(addr string, handler http.Handler) *HttpServer {
 	return &HttpServer{Server: &http.Server{
-		Addr:    "127.0.0.1:8080",
+		Addr:    addr,
 		Handler: handler,
 	}}
 }

--- a/helper.go
+++ b/helper.go
@@ -1,5 +1,11 @@
 package goscade
 
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
 // Register is a convenience function that registers a component with the lifecycle
 // manager and returns the same component. This allows for fluent-style registration
 // and makes it easier to chain component creation and registration.
@@ -21,4 +27,43 @@ package goscade
 func Register[T Component](lc Lifecycle, component T, implicitDeps ...Component) T {
 	lc.Register(component, implicitDeps...)
 	return component
+}
+
+// Run executes a single component with blocking behavior and readiness callback.
+// This is a convenience function for running individual components outside of
+// a lifecycle manager. The method blocks until the component is ready or fails.
+//
+// Parameters:
+//   - ctx: Context for cancellation
+//   - comp: Component to run
+//   - ready: Callback function called when component is ready
+//
+// Returns:
+//   - error: Any error that occurred during component execution
+//
+// Example:
+//
+//	err := goscade.Run(ctx, &MyComponent{}, func() {
+//		log.Info("Component is ready")
+//	})
+func Run(ctx context.Context, comp Component, ready func()) error {
+	probe, cancelProbe := context.WithCancelCause(ctx)
+	res := make(chan error)
+	go func() {
+		res <- comp.Run(ctx, func(err error) {
+			cancelProbe(err)
+		})
+	}()
+
+	<-probe.Done()
+	if err := context.Cause(probe); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("readiness probe failed: %w", err)
+	}
+
+	ready()
+	if err := <-res; err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("lifecycle run failed: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Add Register() helper function for fluent component registration
- Add Run() helper function for simplified lifecycle execution
- Enhance lifecycle management with improved error handling
- Add comprehensive test coverage for new functionality
- Update example application with new API usage
- Improve component dependency management and startup order
- Add support for graceful shutdown hooks with WithShutdownHook()
- Enhance lifecycle status transitions and error propagation

BREAKING CHANGES:
- Lifecycle.Run() method signature changed:
  - OLD: Run(ctx context.Context, readinessProbe func(err error)) func() error
  - NEW: Run(ctx context.Context, readinessProbe func(err error)) error
- Lifecycle is now a Component without casting
- Added blocking Run() helper method with callback support
- Lifecycle no longer shuts down on signals by default (use WithShutdownHook() option)

Migration guide:
- Replace: waitFn := lc.Run(ctx, probe); err := waitFn()
- With: err := lc.Run(ctx, probe)
- Use goscade.Run() helper for blocking execution with callback
- Add WithShutdownHook() option if signal handling is needed