### PR TITLE
feat: add Link for explicit dependencies on arbitrary structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ If you need to declare dependencies that cannot be detected via reflection (e.g.
 goscade.Register(lc, service, db)
 ```
 
+#### Linking dependencies through an arbitrary struct
+
+When a component has no reflectable field path to the components it depends on
+(the link runs through a wiring struct, closures, etc.), use `Link` to point it
+at an arbitrary struct. The struct is reflection-walked during graph building
+and every registered component reachable inside it becomes a parent — as if the
+component had a field referencing that struct. The struct itself is never a node
+and is never run.
+
+```go
+// wiring is a plain struct, not a Component.
+type wiring struct {
+    DB    *Database
+    Cache *Cache
+}
+
+w := &wiring{DB: db, Cache: cache}
+
+// service depends on every registered component reachable inside w (db, cache),
+// even though service has no field referencing them.
+goscade.Link(lc, service, w)
+```
+
 ### Adapter Pattern
 
 Use `NewAdapter` to wrap existing types (like `http.Server`) without defining a new struct.

--- a/dependencies.go
+++ b/dependencies.go
@@ -24,6 +24,13 @@ func (lc *lifecycle) findParentComponents(root Component) map[Component]struct{}
 		parents[dep] = struct{}{}
 	}
 
+	// Explicit struct deps (from Link) are seeded as extra traversal roots so
+	// the BFS below walks them exactly as if they were fields of root. They are
+	// pushed AFTER root's own value, so the self-skip logic still excludes root.
+	for _, dep := range lc.compToLinkedDeps[root] {
+		queue.Push(reflect.ValueOf(dep))
+	}
+
 	var initialized bool
 	for !queue.IsEmpty() {
 		val, _ := queue.Pop()

--- a/dependencies_test.go
+++ b/dependencies_test.go
@@ -60,6 +60,158 @@ func newTestLifecycle() *lifecycle {
 	return NewLifecycle(&mockLogger{}).(*lifecycle)
 }
 
+// TestLink_RegistersComponentAndStoresDeps verifies Link registers the
+// component (idempotent) and records the explicit struct deps.
+func TestLink_RegistersComponentAndStoresDeps(t *testing.T) {
+	lc := newTestLifecycle()
+
+	comp := &mockComponent{name: "test"}
+	type wiring struct{ X int }
+	w := &wiring{X: 1}
+
+	lc.Link(comp, w)
+
+	if _, ok := lc.components[comp]; !ok {
+		t.Fatalf("expected Link to register the component")
+	}
+	if len(lc.compToLinkedDeps[comp]) != 1 {
+		t.Fatalf("expected 1 explicit dep, got %d", len(lc.compToLinkedDeps[comp]))
+	}
+
+	// Idempotent: calling Link again appends, does not duplicate the component.
+	lc.Link(comp, w)
+	if len(lc.components) != 1 {
+		t.Fatalf("expected 1 component after second Link, got %d", len(lc.components))
+	}
+	if len(lc.compToLinkedDeps[comp]) != 2 {
+		t.Fatalf("expected 2 explicit deps after second Link, got %d", len(lc.compToLinkedDeps[comp]))
+	}
+}
+
+// TestLink_DiscoversComponentBehindStruct verifies that a component with no
+// field reference to another component still gets it as a parent when an
+// arbitrary struct that references it is linked explicitly.
+func TestLink_DiscoversComponentBehindStruct(t *testing.T) {
+	lc := newTestLifecycle()
+
+	dep := Register(lc, &mockComponent{name: "dep"})
+
+	// wiring is NOT a Component; it holds a reference to dep.
+	type wiring struct {
+		Comp *mockComponent
+	}
+	w := &wiring{Comp: dep}
+
+	// root has no field referencing dep at all.
+	root := &mockComponent{name: "root"}
+	lc.Link(root, w)
+
+	parents := lc.findParentComponents(root)
+	if len(parents) != 1 {
+		t.Fatalf("expected 1 parent discovered through the lens, got %d", len(parents))
+	}
+	if _, ok := parents[dep]; !ok {
+		t.Fatalf("expected dep to be a parent of root")
+	}
+}
+
+// TestLinkHelper_ReturnsComponentAndLinks verifies the package-level Link
+// helper registers, links, and returns the same component.
+func TestLinkHelper_ReturnsComponentAndLinks(t *testing.T) {
+	lc := newTestLifecycle()
+
+	dep := Register(lc, &mockComponent{name: "dep"})
+	type wiring struct{ Comp *mockComponent }
+	w := &wiring{Comp: dep}
+
+	root := Link(lc, &mockComponent{name: "root"}, w)
+
+	if root == nil {
+		t.Fatalf("expected Link to return the component")
+	}
+	parents := lc.findParentComponents(root)
+	if _, ok := parents[dep]; !ok {
+		t.Fatalf("expected dep to be a parent of root via the helper")
+	}
+}
+
+// TestLink_NoSelfParent verifies a lens that references the component itself
+// does not produce a self-parent.
+func TestLink_NoSelfParent(t *testing.T) {
+	lc := newTestLifecycle()
+
+	root := Register(lc, &mockComponent{name: "root"})
+	type wiring struct{ Self *mockComponent }
+	w := &wiring{Self: root}
+	lc.Link(root, w)
+
+	parents := lc.findParentComponents(root)
+	if len(parents) != 0 {
+		t.Fatalf("expected no self-parent, got %d parents", len(parents))
+	}
+}
+
+// TestLink_EmptyAndNilDeps verifies Link with no deps or a nil dep is safe.
+func TestLink_EmptyAndNilDeps(t *testing.T) {
+	lc := newTestLifecycle()
+
+	root := &mockComponent{name: "root"}
+	lc.Link(root)      // no deps
+	lc.Link(root, nil) // nil dep
+
+	parents := lc.findParentComponents(root)
+	if len(parents) != 0 {
+		t.Fatalf("expected no parents, got %d", len(parents))
+	}
+}
+
+// TestLink_MultipleComponentsBehindStruct verifies all components reachable
+// inside the lens (incl. nested structs) become parents.
+func TestLink_MultipleComponentsBehindStruct(t *testing.T) {
+	lc := newTestLifecycle()
+
+	a := Register(lc, &mockComponent{name: "a"})
+	b := Register(lc, &mockComponent{name: "b"})
+
+	type inner struct{ B *mockComponent }
+	type wiring struct {
+		A     *mockComponent
+		Inner inner
+	}
+	w := &wiring{A: a, Inner: inner{B: b}}
+
+	root := &mockComponent{name: "root"}
+	lc.Link(root, w)
+
+	parents := lc.findParentComponents(root)
+	if len(parents) != 2 {
+		t.Fatalf("expected 2 parents, got %d", len(parents))
+	}
+	if _, ok := parents[a]; !ok {
+		t.Fatalf("expected a to be a parent")
+	}
+	if _, ok := parents[b]; !ok {
+		t.Fatalf("expected b to be a parent")
+	}
+}
+
+// TestLink_CycleViaLensPanics verifies a cycle introduced through a lens is
+// detected by Dependencies().
+func TestLink_CycleViaLensPanics(t *testing.T) {
+	lc := newTestLifecycle()
+
+	a := Register(lc, &mockComponent{name: "a"})
+	b := Register(lc, &mockComponent{name: "b"})
+
+	// a depends on b, and b depends on a — both via lenses → cycle.
+	type wiringA struct{ B *mockComponent }
+	type wiringB struct{ A *mockComponent }
+	lc.Link(a, &wiringA{B: b})
+	lc.Link(b, &wiringB{A: a})
+
+	assert.Panicsf(t, func() { lc.Dependencies() }, "expected panic due to cycle via lenses")
+}
+
 // TestFindParentComponents_Empty tests findParentComponents with empty values
 func TestFindParentComponents_Empty(t *testing.T) {
 	lc := newTestLifecycle()

--- a/helper.go
+++ b/helper.go
@@ -29,6 +29,18 @@ func Register[T Component](lc Lifecycle, component T, implicitDeps ...Component)
 	return component
 }
 
+// Link is a convenience function that registers a component, declares explicit
+// struct dependencies on it (see Lifecycle.Link), and returns the same
+// component for fluent-style wiring.
+//
+// Example:
+//
+//	root := Link(lc, NewService(), wiringStruct) // root depends on components inside wiringStruct
+func Link[T Component](lc Lifecycle, component T, deps ...any) T {
+	lc.Link(component, deps...)
+	return component
+}
+
 // Run executes a single component with blocking behavior and readiness callback.
 // This is a convenience function for running individual components outside of
 // a lifecycle manager. The method blocks until the component is ready or fails.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -76,6 +76,14 @@ type Lifecycle interface {
 	// detection is not sufficient (e.g., interface dependencies, function parameters).
 	Register(component Component, implicitDeps ...Component)
 
+	// Link declares explicit dependencies on arbitrary structs for component.
+	// Each struct in deps is reflection-walked during dependency analysis, and
+	// every registered Component reachable inside it becomes a parent of
+	// component — exactly as if component had a field referencing that struct.
+	// The structs are never nodes in the graph and are never run.
+	// component is registered if it was not already (idempotent).
+	Link(component Component, deps ...any)
+
 	// Run starts all registered components and blocks until shutdown.
 	// The method handles dependency resolution, concurrent startup, and graceful shutdown.
 	// The readinessProbe callback is called when all components are ready or if there's an error during startup.
@@ -92,6 +100,7 @@ type lifecycle struct {
 	status             LifecycleStatus
 	statusListener     chan LifecycleStatus
 	compToImplicitDeps map[Component]map[Component]struct{}
+	compToLinkedDeps   map[Component][]any
 	components         map[Component]struct{}
 	ptrToComp          map[uintptr]Component
 	log                logger
@@ -150,6 +159,7 @@ func NewLifecycle(log logger, opts ...Option) Lifecycle {
 		log:                log,
 		status:             LifecycleStatusIdle,
 		compToImplicitDeps: make(map[Component]map[Component]struct{}),
+		compToLinkedDeps:   make(map[Component][]any),
 		statusListener:     make(chan LifecycleStatus),
 		components:         make(map[Component]struct{}),
 		ptrToComp:          make(map[uintptr]Component),
@@ -184,6 +194,16 @@ func (lc *lifecycle) Register(comp Component, implicitDeps ...Component) {
 		lc.Register(dep)
 		lc.compToImplicitDeps[comp][dep] = struct{}{}
 	}
+}
+
+// Link declares explicit dependencies on arbitrary structs for comp.
+// It registers comp if necessary (idempotent), then records each dep so that
+// findParentComponents walks it during dependency analysis. Any registered
+// Component reachable inside a dep becomes a parent of comp. The deps themselves
+// are never registered as components and are never run.
+func (lc *lifecycle) Link(comp Component, deps ...any) {
+	lc.Register(comp)
+	lc.compToLinkedDeps[comp] = append(lc.compToLinkedDeps[comp], deps...)
 }
 
 // setStatus updates the lifecycle status with proper state transition validation.


### PR DESCRIPTION
A component can now declare a dependency on any struct (not just another Component) via Link. During dependency analysis the struct is reflection- walked and every registered Component reachable inside it becomes a parent of the component — as if the component had a field referencing that struct. The struct itself is never a graph node and is never run.